### PR TITLE
Add missing parenthesis in multiple makefiles that broke "make help"

### DIFF
--- a/cpp_kernels/array_partition/Makefile
+++ b/cpp_kernels/array_partition/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/burst_rw/Makefile
+++ b/cpp_kernels/burst_rw/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/critical_path/Makefile
+++ b/cpp_kernels/critical_path/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/custom_datatype/Makefile
+++ b/cpp_kernels/custom_datatype/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/dataflow_stream/Makefile
+++ b/cpp_kernels/dataflow_stream/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/dataflow_stream_array/Makefile
+++ b/cpp_kernels/dataflow_stream_array/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/dependence_inter/Makefile
+++ b/cpp_kernels/dependence_inter/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/gmem_2banks/Makefile
+++ b/cpp_kernels/gmem_2banks/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/kernel_chain/Makefile
+++ b/cpp_kernels/kernel_chain/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/kernel_global_bandwidth/Makefile
+++ b/cpp_kernels/kernel_global_bandwidth/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/lmem_2rw/Makefile
+++ b/cpp_kernels/lmem_2rw/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/loop_pipeline/Makefile
+++ b/cpp_kernels/loop_pipeline/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/loop_reorder/Makefile
+++ b/cpp_kernels/loop_reorder/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/partition_cyclicblock/Makefile
+++ b/cpp_kernels/partition_cyclicblock/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/plram_access/Makefile
+++ b/cpp_kernels/plram_access/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/shift_register/Makefile
+++ b/cpp_kernels/shift_register/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/systolic_array/Makefile
+++ b/cpp_kernels/systolic_array/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/cpp_kernels/wide_mem_rw/Makefile
+++ b/cpp_kernels/wide_mem_rw/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/concurrent_kernel_execution/Makefile
+++ b/host/concurrent_kernel_execution/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/copy_buffer/Makefile
+++ b/host/copy_buffer/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/data_transfer/Makefile
+++ b/host/data_transfer/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/debug_profile/Makefile
+++ b/host/debug_profile/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/device_only_buffer/Makefile
+++ b/host/device_only_buffer/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/device_query/Makefile
+++ b/host/device_query/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/errors/Makefile
+++ b/host/errors/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/errors_cpp/Makefile
+++ b/host/errors_cpp/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/hbm_bandwidth/Makefile
+++ b/host/hbm_bandwidth/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/hbm_simple/Makefile
+++ b/host/hbm_simple/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/host_global_bandwidth/Makefile
+++ b/host/host_global_bandwidth/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/mult_compute_units/Makefile
+++ b/host/mult_compute_units/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/multiple_cus_asymmetrical/Makefile
+++ b/host/multiple_cus_asymmetrical/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/overlap/Makefile
+++ b/host/overlap/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/p2p_bandwidth/Makefile
+++ b/host/p2p_bandwidth/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/p2p_simple/Makefile
+++ b/host/p2p_simple/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/streaming_free_running_kernel/Makefile
+++ b/host/streaming_free_running_kernel/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/streaming_host_bandwidth/Makefile
+++ b/host/streaming_host_bandwidth/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/streaming_k2k/Makefile
+++ b/host/streaming_k2k/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/streaming_k2k_mm/Makefile
+++ b/host/streaming_k2k_mm/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/streaming_mm_mixed/Makefile
+++ b/host/streaming_mm_mixed/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/streaming_multi_cus/Makefile
+++ b/host/streaming_multi_cus/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/host/streaming_simple/Makefile
+++ b/host/streaming_simple/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_array_partition/Makefile
+++ b/ocl_kernels/cl_array_partition/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_burst_rw/Makefile
+++ b/ocl_kernels/cl_burst_rw/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_dataflow_func/Makefile
+++ b/ocl_kernels/cl_dataflow_func/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_dataflow_subfunc/Makefile
+++ b/ocl_kernels/cl_dataflow_subfunc/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_gmem_2banks/Makefile
+++ b/ocl_kernels/cl_gmem_2banks/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_helloworld/Makefile
+++ b/ocl_kernels/cl_helloworld/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_lmem_2rw/Makefile
+++ b/ocl_kernels/cl_lmem_2rw/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_loop_reorder/Makefile
+++ b/ocl_kernels/cl_loop_reorder/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_partition_cyclicblock/Makefile
+++ b/ocl_kernels/cl_partition_cyclicblock/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_shift_register/Makefile
+++ b/ocl_kernels/cl_shift_register/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_systolic_array/Makefile
+++ b/ocl_kernels/cl_systolic_array/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/ocl_kernels/cl_wide_mem_rw/Makefile
+++ b/ocl_kernels/cl_wide_mem_rw/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_adder_streams/Makefile
+++ b/rtl_kernels/rtl_adder_streams/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_streaming_free_running/Makefile
+++ b/rtl_kernels/rtl_streaming_free_running/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_streaming_k2k/Makefile
+++ b/rtl_kernels/rtl_streaming_k2k/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_streaming_k2k_mm/Makefile
+++ b/rtl_kernels/rtl_streaming_k2k_mm/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_vadd/Makefile
+++ b/rtl_kernels/rtl_vadd/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_vadd_2clks/Makefile
+++ b/rtl_kernels/rtl_vadd_2clks/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_vadd_2kernels/Makefile
+++ b/rtl_kernels/rtl_vadd_2kernels/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_vadd_hw_debug/Makefile
+++ b/rtl_kernels/rtl_vadd_hw_debug/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/rtl_kernels/rtl_vadd_mixed_c_vadd/Makefile
+++ b/rtl_kernels/rtl_vadd_mixed_c_vadd/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/sys_opt/advanced_config/Makefile
+++ b/sys_opt/advanced_config/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/sys_opt/kernel_swap/Makefile
+++ b/sys_opt/kernel_swap/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/sys_opt/multiple_devices/Makefile
+++ b/sys_opt/multiple_devices/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/sys_opt/multiple_process/Makefile
+++ b/sys_opt/multiple_process/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"

--- a/sys_opt/slr_assign/Makefile
+++ b/sys_opt/slr_assign/Makefile
@@ -14,7 +14,7 @@ help::
 	$(ECHO) ""
 	$(ECHO)  "  make test DEVICE=<FPGA platform>"
 	$(ECHO)  "     Command to run the application. This is same as 'check' target but does not have any makefile dependency."
-	$ECHO)  ""
+	$(ECHO)  ""
 	$(ECHO) "  make sd_card TARGET=<sw_emu/hw_emu/hw> DEVICE=<FPGA platform> HOST_ARCH=<aarch32/aarch64/x86> SYSROOT=<sysroot_path>"
 	$(ECHO) "      Command to prepare sd_card files."
 	$(ECHO) "      By default, HOST_ARCH=x86. HOST_ARCH and SYSROOT is required for SoC shells"


### PR DESCRIPTION
Fixes "make help" in multiple examples.