### PR TITLE
Add 'cd /mnt/' to init.ini for SD Card generation during compilation flow, similar to emulation flows

### DIFF
--- a/cpp_kernels/array_partition/Makefile
+++ b/cpp_kernels/array_partition/Makefile
@@ -150,6 +150,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/burst_rw/Makefile
+++ b/cpp_kernels/burst_rw/Makefile
@@ -147,6 +147,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/critical_path/Makefile
+++ b/cpp_kernels/critical_path/Makefile
@@ -150,6 +150,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/custom_datatype/Makefile
+++ b/cpp_kernels/custom_datatype/Makefile
@@ -149,6 +149,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/dataflow_stream/Makefile
+++ b/cpp_kernels/dataflow_stream/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/dataflow_stream_array/Makefile
+++ b/cpp_kernels/dataflow_stream_array/Makefile
@@ -147,6 +147,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/dependence_inter/Makefile
+++ b/cpp_kernels/dependence_inter/Makefile
@@ -153,6 +153,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/gmem_2banks/Makefile
+++ b/cpp_kernels/gmem_2banks/Makefile
@@ -165,6 +165,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/kernel_chain/Makefile
+++ b/cpp_kernels/kernel_chain/Makefile
@@ -160,6 +160,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/kernel_global_bandwidth/Makefile
+++ b/cpp_kernels/kernel_global_bandwidth/Makefile
@@ -155,6 +155,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/lmem_2rw/Makefile
+++ b/cpp_kernels/lmem_2rw/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/loop_pipeline/Makefile
+++ b/cpp_kernels/loop_pipeline/Makefile
@@ -150,6 +150,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/loop_reorder/Makefile
+++ b/cpp_kernels/loop_reorder/Makefile
@@ -148,6 +148,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/partition_cyclicblock/Makefile
+++ b/cpp_kernels/partition_cyclicblock/Makefile
@@ -150,6 +150,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/plram_access/Makefile
+++ b/cpp_kernels/plram_access/Makefile
@@ -158,6 +158,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/shift_register/Makefile
+++ b/cpp_kernels/shift_register/Makefile
@@ -147,6 +147,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/systolic_array/Makefile
+++ b/cpp_kernels/systolic_array/Makefile
@@ -153,6 +153,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/cpp_kernels/wide_mem_rw/Makefile
+++ b/cpp_kernels/wide_mem_rw/Makefile
@@ -153,6 +153,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/concurrent_kernel_execution/Makefile
+++ b/host/concurrent_kernel_execution/Makefile
@@ -154,6 +154,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/copy_buffer/Makefile
+++ b/host/copy_buffer/Makefile
@@ -153,6 +153,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/data_transfer/Makefile
+++ b/host/data_transfer/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/debug_profile/Makefile
+++ b/host/debug_profile/Makefile
@@ -147,6 +147,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/device_only_buffer/Makefile
+++ b/host/device_only_buffer/Makefile
@@ -150,6 +150,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/errors/Makefile
+++ b/host/errors/Makefile
@@ -143,6 +143,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/errors_cpp/Makefile
+++ b/host/errors_cpp/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/hbm_bandwidth/Makefile
+++ b/host/hbm_bandwidth/Makefile
@@ -164,6 +164,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/hbm_simple/Makefile
+++ b/host/hbm_simple/Makefile
@@ -164,6 +164,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/host_global_bandwidth/Makefile
+++ b/host/host_global_bandwidth/Makefile
@@ -161,6 +161,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/mult_compute_units/Makefile
+++ b/host/mult_compute_units/Makefile
@@ -148,6 +148,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/multiple_cus_asymmetrical/Makefile
+++ b/host/multiple_cus_asymmetrical/Makefile
@@ -158,6 +158,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/overlap/Makefile
+++ b/host/overlap/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/p2p_bandwidth/Makefile
+++ b/host/p2p_bandwidth/Makefile
@@ -165,6 +165,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/p2p_simple/Makefile
+++ b/host/p2p_simple/Makefile
@@ -165,6 +165,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/streaming_free_running_kernel/Makefile
+++ b/host/streaming_free_running_kernel/Makefile
@@ -175,6 +175,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/streaming_host_bandwidth/Makefile
+++ b/host/streaming_host_bandwidth/Makefile
@@ -162,6 +162,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/streaming_k2k/Makefile
+++ b/host/streaming_k2k/Makefile
@@ -168,6 +168,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/streaming_k2k_mm/Makefile
+++ b/host/streaming_k2k_mm/Makefile
@@ -159,6 +159,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/streaming_mm_mixed/Makefile
+++ b/host/streaming_mm_mixed/Makefile
@@ -162,6 +162,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/streaming_multi_cus/Makefile
+++ b/host/streaming_multi_cus/Makefile
@@ -164,6 +164,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/host/streaming_simple/Makefile
+++ b/host/streaming_simple/Makefile
@@ -162,6 +162,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_array_partition/Makefile
+++ b/ocl_kernels/cl_array_partition/Makefile
@@ -150,6 +150,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_burst_rw/Makefile
+++ b/ocl_kernels/cl_burst_rw/Makefile
@@ -148,6 +148,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_dataflow_func/Makefile
+++ b/ocl_kernels/cl_dataflow_func/Makefile
@@ -147,6 +147,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_dataflow_subfunc/Makefile
+++ b/ocl_kernels/cl_dataflow_subfunc/Makefile
@@ -147,6 +147,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_gmem_2banks/Makefile
+++ b/ocl_kernels/cl_gmem_2banks/Makefile
@@ -162,6 +162,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_helloworld/Makefile
+++ b/ocl_kernels/cl_helloworld/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_lmem_2rw/Makefile
+++ b/ocl_kernels/cl_lmem_2rw/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_loop_reorder/Makefile
+++ b/ocl_kernels/cl_loop_reorder/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_partition_cyclicblock/Makefile
+++ b/ocl_kernels/cl_partition_cyclicblock/Makefile
@@ -157,6 +157,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_shift_register/Makefile
+++ b/ocl_kernels/cl_shift_register/Makefile
@@ -147,6 +147,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_systolic_array/Makefile
+++ b/ocl_kernels/cl_systolic_array/Makefile
@@ -150,6 +150,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/ocl_kernels/cl_wide_mem_rw/Makefile
+++ b/ocl_kernels/cl_wide_mem_rw/Makefile
@@ -153,6 +153,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_adder_streams/Makefile
+++ b/rtl_kernels/rtl_adder_streams/Makefile
@@ -152,6 +152,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_streaming_free_running/Makefile
+++ b/rtl_kernels/rtl_streaming_free_running/Makefile
@@ -165,6 +165,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_streaming_k2k/Makefile
+++ b/rtl_kernels/rtl_streaming_k2k/Makefile
@@ -168,6 +168,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_streaming_k2k_mm/Makefile
+++ b/rtl_kernels/rtl_streaming_k2k_mm/Makefile
@@ -154,6 +154,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_vadd/Makefile
+++ b/rtl_kernels/rtl_vadd/Makefile
@@ -148,6 +148,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_vadd_2clks/Makefile
+++ b/rtl_kernels/rtl_vadd_2clks/Makefile
@@ -150,6 +150,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_vadd_2kernels/Makefile
+++ b/rtl_kernels/rtl_vadd_2kernels/Makefile
@@ -149,6 +149,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_vadd_hw_debug/Makefile
+++ b/rtl_kernels/rtl_vadd_hw_debug/Makefile
@@ -148,6 +148,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/rtl_kernels/rtl_vadd_mixed_c_vadd/Makefile
+++ b/rtl_kernels/rtl_vadd_mixed_c_vadd/Makefile
@@ -149,6 +149,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/sys_opt/advanced_config/Makefile
+++ b/sys_opt/advanced_config/Makefile
@@ -147,6 +147,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/sys_opt/kernel_swap/Makefile
+++ b/sys_opt/kernel_swap/Makefile
@@ -159,6 +159,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/sys_opt/multiple_devices/Makefile
+++ b/sys_opt/multiple_devices/Makefile
@@ -146,6 +146,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/sys_opt/multiple_process/Makefile
+++ b/sys_opt/multiple_process/Makefile
@@ -158,6 +158,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif

--- a/sys_opt/slr_assign/Makefile
+++ b/sys_opt/slr_assign/Makefile
@@ -159,6 +159,7 @@ ifeq ($(TARGET),$(filter $(TARGET),sw_emu hw_emu))
 	$(ECHO) 'reboot' >> $(SDCARD)/init.sh
 else
 	[ -f $(SDCARD)/BOOT.BIN ] && echo "INFO: BOOT.BIN already exists" || $(CP) $(BUILD_DIR)/sd_card/BOOT.BIN $(SDCARD)/
+	$(ECHO) 'cd /mnt/' >> $(SDCARD)/init.sh
 	$(ECHO) './$(EXECUTABLE) $(CMD_ARGS)' >> $(SDCARD)/init.sh
 endif
 endif


### PR DESCRIPTION
The way the init.sh script is generated right now for SD Card creation, the script will fail to run the host binary after boot since the SD Card is mounted at /mnt/ and a 'cd /mnt/' is required first before the host binary can be executed. This is already included in SD Card generation for the emulation flow (TARGET={sw|hw}_emu), but not for the full compilation flow (TARGET=hw). Tested on ZCU104 board.