### PR TITLE
Update krnl_vadd_rtl_control_s_axi.v

### DIFF
--- a/rtl_kernels/rtl_vadd/src/krnl_vadd/hdl/krnl_vadd_rtl_control_s_axi.v
+++ b/rtl_kernels/rtl_vadd/src/krnl_vadd/hdl/krnl_vadd_rtl_control_s_axi.v
@@ -113,7 +113,7 @@ localparam
     WRRESP               = 2'd2,
     RDIDLE               = 2'd0,
     RDDATA               = 2'd1,
-    ADDR_BITS         = 6;
+    ADDR_BITS            = C_S_AXI_ADDR_WIDTH;
 
 //------------------------Local signal-------------------
     reg  [1:0]                    wstate = WRIDLE;


### PR DESCRIPTION
ADDR_BITS must be equal to C_S_AXI_ADDR_WIDTH. If the user wants to add more arguments then it will create a bug, that is not easily detected.