### PR TITLE
IP-LOCK-01 warning suppression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Welcome to the Vitis Data Center Acceleration Examples repository. This reposito
 
 For more comprehensive documentation, <a href="http://xilinx.github.io/Vitis_Accel_Examples/"><img src="https://img.shields.io/badge/click-here-green?style=plastic&logo=appveyor"/></a>
 
+## Note
+To suppress IP-LOCK-01 warning message set this environment variable:
+```
+export VPPDISABLEDRC=--drc.disable=IP-LOCK-01
+```
+
 
 <p class="sphinxhide" align="center"><sub>Copyright © 2020–2025 Advanced Micro Devices, Inc</sub></p>
 

--- a/hello_world/makefile_us_alveo.mk
+++ b/hello_world/makefile_us_alveo.mk
@@ -96,7 +96,7 @@ $(TEMP_DIR)/vadd.xo: src/vadd.cpp
 
 $(BUILD_DIR)/vadd.xclbin: $(TEMP_DIR)/vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vadd.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_py/hello_world_py/makefile_us_alveo.mk
+++ b/host_py/hello_world_py/makefile_us_alveo.mk
@@ -88,7 +88,7 @@ $(TEMP_DIR)/vadd.xo: src/vadd.cpp
 
 $(BUILD_DIR)/vadd.xclbin: $(TEMP_DIR)/vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vadd.xclbin
 
 emconfig:$(EMCONFIG_DIR)/emconfig.json

--- a/host_xrt/asynchronous_xrt/makefile_us_alveo.mk
+++ b/host_xrt/asynchronous_xrt/makefile_us_alveo.mk
@@ -97,7 +97,7 @@ $(TEMP_DIR)/vadd.xo: src/vadd.cpp
 
 $(BUILD_DIR)/vadd.xclbin: $(TEMP_DIR)/vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vadd.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/copy_buffer_xrt/makefile_us_alveo.mk
+++ b/host_xrt/copy_buffer_xrt/makefile_us_alveo.mk
@@ -96,7 +96,7 @@ $(TEMP_DIR)/vector_add.xo: src/vector_addition.cpp
 
 $(BUILD_DIR)/vector_addition.xclbin: $(TEMP_DIR)/vector_add.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vector_addition.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/data_transfer_xrt/makefile_us_alveo.mk
+++ b/host_xrt/data_transfer_xrt/makefile_us_alveo.mk
@@ -96,7 +96,7 @@ $(TEMP_DIR)/dummy_kernel.xo: src/dummy_kernel.cpp
 
 $(BUILD_DIR)/dummy_kernel.xclbin: $(TEMP_DIR)/dummy_kernel.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/dummy_kernel.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/hbm_simple_xrt/makefile_us_alveo.mk
+++ b/host_xrt/hbm_simple_xrt/makefile_us_alveo.mk
@@ -98,7 +98,7 @@ $(TEMP_DIR)/krnl_vadd.xo: src/krnl_vadd.cpp
 
 $(BUILD_DIR)/krnl_vadd.xclbin: $(TEMP_DIR)/krnl_vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vadd) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vadd) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_vadd.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/host_memory_copy_kernel_xrt/makefile_us_alveo.mk
+++ b/host_xrt/host_memory_copy_kernel_xrt/makefile_us_alveo.mk
@@ -110,7 +110,7 @@ $(TEMP_DIR)/copy_kernel.xo: src/copy_kernel.cpp
 
 $(BUILD_DIR)/krnl_vadd.xclbin: $(TEMP_DIR)/krnl_vadd.xo $(TEMP_DIR)/copy_kernel.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vadd) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vadd) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_vadd.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/host_memory_simple_xrt/makefile_us_alveo.mk
+++ b/host_xrt/host_memory_simple_xrt/makefile_us_alveo.mk
@@ -100,7 +100,7 @@ $(TEMP_DIR)/krnl_vadd.xo: src/kernel.cpp
 
 $(BUILD_DIR)/krnl_vadd.xclbin: $(TEMP_DIR)/krnl_vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vadd) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vadd) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_vadd.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/kernel_chain/makefile_us_alveo.mk
+++ b/host_xrt/kernel_chain/makefile_us_alveo.mk
@@ -98,7 +98,7 @@ $(TEMP_DIR)/krnl_simple_mmult.xo: src/krnl_simple_mmult.cpp
 
 $(BUILD_DIR)/krnl_mmult.xclbin: $(TEMP_DIR)/krnl_chain_mmult.xo $(TEMP_DIR)/krnl_simple_mmult.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_mmult.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/mailbox_auto_restart_xrt/makefile_us_alveo.mk
+++ b/host_xrt/mailbox_auto_restart_xrt/makefile_us_alveo.mk
@@ -98,7 +98,7 @@ $(TEMP_DIR)/mbox_autorestart.xo: src/mbox_autorestart.cpp
 
 $(BUILD_DIR)/mbox_autorestart.xclbin: $(TEMP_DIR)/mbox_autorestart.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/mbox_autorestart.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/mult_compute_units_xrt/makefile_us_alveo.mk
+++ b/host_xrt/mult_compute_units_xrt/makefile_us_alveo.mk
@@ -98,7 +98,7 @@ $(TEMP_DIR)/vadd.xo: src/vadd.cpp
 
 $(BUILD_DIR)/vadd.xclbin: $(TEMP_DIR)/vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_vadd) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_vadd) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vadd.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/streaming_free_running_k2k_xrt/makefile_us_alveo.mk
+++ b/host_xrt/streaming_free_running_k2k_xrt/makefile_us_alveo.mk
@@ -104,7 +104,7 @@ $(TEMP_DIR)/mem_write.xo: src/mem_write.cpp
 
 $(BUILD_DIR)/krnl_incr.xclbin: $(TEMP_DIR)/mem_read.xo $(TEMP_DIR)/increment.xo $(TEMP_DIR)/mem_write.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_incr) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_incr) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_incr.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/host_xrt/streaming_k2k_mm_xrt/makefile_us_alveo.mk
+++ b/host_xrt/streaming_k2k_mm_xrt/makefile_us_alveo.mk
@@ -101,7 +101,7 @@ $(TEMP_DIR)/krnl_stream_vmult.xo: src/krnl_stream_vmult.cpp
 
 $(BUILD_DIR)/krnl_stream_vadd_vmult.xclbin: $(TEMP_DIR)/krnl_stream_vadd.xo $(TEMP_DIR)/krnl_stream_vmult.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_stream_vadd_vmult) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_stream_vadd_vmult) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_stream_vadd_vmult.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/performance/axi_burst_performance/makefile_us_alveo.mk
+++ b/performance/axi_burst_performance/makefile_us_alveo.mk
@@ -146,12 +146,12 @@ $(TEMP_DIR)/test_kernel_maxi_512bit_6.xo: src/test_kernel_maxi_512bit_6.cpp
 	$(VPP) -c $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) -k test_kernel_maxi_512bit_6 --temp_dir $(TEMP_DIR)  -I'$(<D)' -o'$@' '$<'
 $(BUILD_DIR)/test_kernel_maxi_256bit.xclbin: $(BINARY_CONTAINER_test_kernel_maxi_256bit_OBJS)
 	mkdir -p $(BUILD_DIR)
-	$(VPP) -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR)  -o'$(BUILD_DIR)/test_kernel_maxi_256bit.link.xclbin' $(+)
+	$(VPP) -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR)  -o'$(BUILD_DIR)/test_kernel_maxi_256bit.link.xclbin' $(+)
 	$(VPP) -p $(BUILD_DIR)/test_kernel_maxi_256bit.link.xclbin $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/test_kernel_maxi_256bit.xclbin
 
 $(BUILD_DIR)/test_kernel_maxi_512bit.xclbin: $(BINARY_CONTAINER_test_kernel_maxi_512bit_OBJS)
 	mkdir -p $(BUILD_DIR)
-	$(VPP) -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR)  -o'$(BUILD_DIR)/test_kernel_maxi_512bit.link.xclbin' $(+)
+	$(VPP) -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR)  -o'$(BUILD_DIR)/test_kernel_maxi_512bit.link.xclbin' $(+)
 	$(VPP) -p $(BUILD_DIR)/test_kernel_maxi_512bit.link.xclbin -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/test_kernel_maxi_512bit.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/performance/hbm_bandwidth/makefile_us_alveo.mk
+++ b/performance/hbm_bandwidth/makefile_us_alveo.mk
@@ -96,7 +96,7 @@ $(TEMP_DIR)/krnl_vaddmul.xo: src/krnl_vaddmul.cpp
 
 $(BUILD_DIR)/krnl_vaddmul.xclbin: $(TEMP_DIR)/krnl_vaddmul.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vaddmul) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vaddmul) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_vaddmul.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/performance/hbm_bandwidth_pseudo_random/makefile_us_alveo.mk
+++ b/performance/hbm_bandwidth_pseudo_random/makefile_us_alveo.mk
@@ -96,7 +96,7 @@ $(TEMP_DIR)/krnl_vaddmul.xo: src/krnl_vaddmul.cpp
 
 $(BUILD_DIR)/krnl_vaddmul.xclbin: $(TEMP_DIR)/krnl_vaddmul.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vaddmul) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_krnl_vaddmul) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_vaddmul.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/performance/host_global_bandwidth/makefile_us_alveo.mk
+++ b/performance/host_global_bandwidth/makefile_us_alveo.mk
@@ -125,7 +125,7 @@ $(TEMP_DIR)/bandwidth.xo: src/kernel.cpp
 
 $(BUILD_DIR)/krnl_host_global.xclbin: $(TEMP_DIR)/bandwidth.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_host_global.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/performance/host_memory_bandwidth/makefile_us_alveo.mk
+++ b/performance/host_memory_bandwidth/makefile_us_alveo.mk
@@ -104,7 +104,7 @@ $(TEMP_DIR)/write_bandwidth.xo: src/write_bandwidth.cpp
 
 $(BUILD_DIR)/bandwidth.xclbin: $(TEMP_DIR)/bandwidth.xo $(TEMP_DIR)/read_bandwidth.xo $(TEMP_DIR)/write_bandwidth.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_bandwidth) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_bandwidth) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/bandwidth.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/performance/host_memory_bandwidth_xrt/makefile_us_alveo.mk
+++ b/performance/host_memory_bandwidth_xrt/makefile_us_alveo.mk
@@ -107,7 +107,7 @@ $(TEMP_DIR)/write_bandwidth.xo: src/write_bandwidth.cpp
 
 $(BUILD_DIR)/bandwidth.xclbin: $(TEMP_DIR)/bandwidth.xo $(TEMP_DIR)/read_bandwidth.xo $(TEMP_DIR)/write_bandwidth.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_bandwidth) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_bandwidth) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/bandwidth.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/performance/iops_test_xrt/makefile_us_alveo.mk
+++ b/performance/iops_test_xrt/makefile_us_alveo.mk
@@ -97,7 +97,7 @@ $(TEMP_DIR)/hello.xo: src/hello.cpp
 
 $(BUILD_DIR)/hello.xclbin: $(TEMP_DIR)/hello.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/hello.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/performance/p2p_fpga2fpga_bandwidth/makefile_us_alveo.mk
+++ b/performance/p2p_fpga2fpga_bandwidth/makefile_us_alveo.mk
@@ -96,7 +96,7 @@ $(TEMP_DIR)/bandwidth.xo: src/bandwidth.cpp
 
 $(BUILD_DIR)/bandwidth.xclbin: $(TEMP_DIR)/bandwidth.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/bandwidth.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/rtl_kernels/rtl_adder_streams/makefile_us_alveo.mk
+++ b/rtl_kernels/rtl_adder_streams/makefile_us_alveo.mk
@@ -94,7 +94,7 @@ xclbin: build
 # Building kernel
 $(BUILD_DIR)/adder.xclbin: $(TEMP_DIR)/input.xo $(TEMP_DIR)/adder.xo $(TEMP_DIR)/output.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_adder) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_adder) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/adder.xclbin
 ############################## Setting Rules for Host (Building Host Executable) ##############################
 $(EXECUTABLE): $(HOST_SRCS) | check-xrt

--- a/rtl_kernels/rtl_streaming_free_running_k2k/makefile_us_alveo.mk
+++ b/rtl_kernels/rtl_streaming_free_running_k2k/makefile_us_alveo.mk
@@ -95,7 +95,7 @@ xclbin: build
 # Building kernel
 $(BUILD_DIR)/myadder.xclbin: $(TEMP_DIR)/myadder.xo $(TEMP_DIR)/krnl_mm2s.xo $(TEMP_DIR)/krnl_s2mm.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_myadder) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_myadder) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/myadder.xclbin
 ############################## Setting Rules for Host (Building Host Executable) ##############################
 $(EXECUTABLE): $(HOST_SRCS) | check-xrt

--- a/rtl_kernels/rtl_streaming_k2k_mm/makefile_us_alveo.mk
+++ b/rtl_kernels/rtl_streaming_k2k_mm/makefile_us_alveo.mk
@@ -95,7 +95,7 @@ xclbin: build
 # Building kernel
 $(BUILD_DIR)/myadder.xclbin: $(TEMP_DIR)/myadder1.xo $(TEMP_DIR)/myadder2.xo $(TEMP_DIR)/krnl_mm2s.xo $(TEMP_DIR)/krnl_s2mm.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_myadder) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_myadder) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/myadder.xclbin
 ############################## Setting Rules for Host (Building Host Executable) ##############################
 $(EXECUTABLE): $(HOST_SRCS) | check-xrt

--- a/rtl_kernels/rtl_vadd_2clks/makefile_us_alveo.mk
+++ b/rtl_kernels/rtl_vadd_2clks/makefile_us_alveo.mk
@@ -92,7 +92,7 @@ xclbin: build
 # Building kernel
 $(BUILD_DIR)/vadd.xclbin: $(TEMP_DIR)/vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vadd.xclbin
 ############################## Setting Rules for Host (Building Host Executable) ##############################
 $(EXECUTABLE): $(HOST_SRCS) | check-xrt

--- a/rtl_kernels/rtl_vadd_2kernels/makefile_us_alveo.mk
+++ b/rtl_kernels/rtl_vadd_2kernels/makefile_us_alveo.mk
@@ -92,7 +92,7 @@ xclbin: build
 # Building kernel
 $(BUILD_DIR)/vadd.xclbin: $(TEMP_DIR)/vadd0.xo $(TEMP_DIR)/vadd1.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vadd.xclbin
 ############################## Setting Rules for Host (Building Host Executable) ##############################
 $(EXECUTABLE): $(HOST_SRCS) | check-xrt

--- a/rtl_kernels/rtl_vadd_hw_debug/makefile_us_alveo.mk
+++ b/rtl_kernels/rtl_vadd_hw_debug/makefile_us_alveo.mk
@@ -95,7 +95,7 @@ xclbin: build
 # Building kernel
 $(BUILD_DIR)/vadd.xclbin: $(TEMP_DIR)/vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_vadd) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) $(VPP_LDFLAGS_vadd) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vadd.xclbin
 ############################## Setting Rules for Host (Building Host Executable) ##############################
 $(EXECUTABLE): $(HOST_SRCS) | check-xrt

--- a/rtl_kernels/rtl_vadd_mixed_c_vadd/makefile_us_alveo.mk
+++ b/rtl_kernels/rtl_vadd_mixed_c_vadd/makefile_us_alveo.mk
@@ -92,7 +92,7 @@ xclbin: build
 # Building kernel
 $(BUILD_DIR)/vadd.xclbin: $(TEMP_DIR)/rtl_vadd.xo $(TEMP_DIR)/krnl_vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vadd.xclbin
 ############################## Setting Rules for Host (Building Host Executable) ##############################
 $(EXECUTABLE): $(HOST_SRCS) | check-xrt

--- a/sys_opt/kernel_swap/makefile_us_alveo.mk
+++ b/sys_opt/kernel_swap/makefile_us_alveo.mk
@@ -103,11 +103,11 @@ $(TEMP_DIR)/krnl_vadd.xo: src/krnl_vadd.cpp
 
 $(BUILD_DIR)/krnl_vmul.xclbin: $(TEMP_DIR)/krnl_vmul.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT_VMUL)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT_VMUL)' $(+)
 	v++ -p $(LINK_OUTPUT_VMUL) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_vmul.xclbin
 $(BUILD_DIR)/krnl_vadd.xclbin: $(TEMP_DIR)/krnl_vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT_VADD)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) -t $(TARGET) --platform $(PLATFORM) $(VPP_LDFLAGS) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT_VADD)' $(+)
 	v++ -p $(LINK_OUTPUT_VADD) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/krnl_vadd.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/sys_opt/multiple_devices/makefile_us_alveo.mk
+++ b/sys_opt/multiple_devices/makefile_us_alveo.mk
@@ -94,7 +94,7 @@ $(TEMP_DIR)/vadd.xo: src/vector_addition.cpp
 
 $(BUILD_DIR)/vector_addition.xclbin: $(TEMP_DIR)/vadd.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/vector_addition.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################

--- a/sys_opt/multiple_process/makefile_us_alveo.mk
+++ b/sys_opt/multiple_process/makefile_us_alveo.mk
@@ -100,7 +100,7 @@ $(TEMP_DIR)/krnl_vsub.xo: src/krnl_vsub.cpp
 
 $(BUILD_DIR)/multi_krnl.xclbin: $(TEMP_DIR)/krnl_vadd.xo $(TEMP_DIR)/krnl_vmul.xo $(TEMP_DIR)/krnl_vsub.xo
 	mkdir -p $(BUILD_DIR)
-	v++ -l $(VPP_FLAGS) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
+	v++ -l $(VPP_FLAGS) $(VPPDISABLEDRC) $(VPP_LDFLAGS) -t $(TARGET) --platform $(PLATFORM) --temp_dir $(TEMP_DIR) -o'$(LINK_OUTPUT)' $(+)
 	v++ -p $(LINK_OUTPUT) $(VPP_FLAGS) -t $(TARGET) --platform $(PLATFORM) --package.out_dir $(PACKAGE_OUT) -o $(BUILD_DIR)/multi_krnl.xclbin
 
 ############################## Setting Rules for Host (Building Host Executable) ##############################


### PR DESCRIPTION
- Added v++ link flag `VPPDISABLEDRC` in `makefile_us_alveo.mk` of all the examples except the ones excluded for AWS F2
- Set `export VPPDISABLEDRC=--drc.disable=IP-LOCK-01` before running make